### PR TITLE
[WIP] Introduce PUT method for updating customer, booking and enquiry

### DIFF
--- a/examples/update-booking-put.json
+++ b/examples/update-booking-put.json
@@ -1,0 +1,89 @@
+{
+  "detail": {
+    "consultationRef": "ABCD",
+    "costings": [
+      {
+        "costCode": "OC",
+        "costUnitValue": 12.35,
+        "costingSequenceNumber": "1354",
+        "description": "Operator cost",
+        "netCost": 10.32,
+        "quantityInvolved": 2
+      }
+    ],
+    "dealFields": {
+      "abta": "L5876",
+      "amountDueDate": "22-FEB-16",
+      "bookingReference": "5300/12345668",
+      "brochureCode": "BC",
+      "brochureCodeDescription": "BCDesc",
+      "cancellationDate": "26 jun 2016",
+      "dateDealConfirmed": "26 may 2016",
+      "dealSequenceNumber": "1",
+      "dealStatusCode": "DSC",
+      "dealStatusCodeDescription": "DSCDesc",
+      "departureDate": "26 oct 2016",
+      "depositAmount": 123.21,
+      "depositDueDate": "26 sep 2016",
+      "lowDepositFlag": "Y",
+      "majorDestination": "LHR",
+      "numberOfAdults": 2,
+      "numberOfChildren": 1,
+      "numberOfInfants": 1,
+      "numberOfSeniorCitizens": 2,
+      "operatorCode": "OP",
+      "operatorCodeDescription": "OPDesc",
+      "productCode": "PC",
+      "productCodeDescription": "PCDesc",
+      "productTypeCode": "PTC",
+      "productTypeCodeDescription": "PTCDesc",
+      "staffEmployeeNumber": "nmb",
+      "totalCostGross": 1354.21,
+      "totalCostNetOfDiscount": 3214.21,
+      "totalDueOnDeal": 25.36,
+      "totalPaid": 325.01,
+      "returnDate": "2015-10-11",
+      "transactionDate": "2014-10-22"
+    },
+    "manifestsCombined": [
+      {
+        "age": 25,
+        "dateOfBirth": "26 may 1982",
+        "firstName": "Doe",
+        "leadPassengerFlag": "Y",
+        "manifestSequenceNumber": "123564",
+        "manifestType": "type",
+        "passengerIncludeFlag": "Y",
+        "passportTypeCode": "UK",
+        "surname": "Jhon",
+        "title": "Mr"
+      }
+    ],
+    "travelLegs": [
+      {
+        "isoCountryCodeArrival": "UA",
+        "isoCountryCodeArrivalDescription": "UADesc",
+        "isoCountryCodeDeparture": "US",
+        "isoCountryCodeDepartureDescription": "USDesc",
+        "sequenceNumber": "13545",
+        "airlineName": "British Airwaivs",
+        "boardBasis": "AllInclusive",
+        "boardBasisDescription": "BSDesc",
+        "cruiseShipName": "Queen Victoria",
+        "description": "resortDesc",
+        "durationDays": 12,
+        "endDate": "26 may 2016",
+        "endTime": "12-28-32",
+        "legType": "type",
+        "locationCodeArrival": "US",
+        "locationCodeDeparture": "locationCode",
+        "locationCodeDepartureDescription": "LCDesc",
+        "propertyCodeOrFlightNumber": "12OCD",
+        "propertyNameOrDestinationName": "13OCD",
+        "startDate": "26 may 2016",
+        "startTime": "12-28-32"
+      }
+    ]
+  },
+  "urn": "ABCD"
+}

--- a/examples/update-customer-put.json
+++ b/examples/update-customer-put.json
@@ -1,0 +1,143 @@
+{
+  "customer": {
+    "identity": {
+      "branchBudgetCentre": "ABCD",
+      "customerReferenceNumber": "ABCD",
+      "title": "Dr",
+      "firstName": "Evelyn",
+      "middlenames": [
+        "Jane"
+      ],
+      "surname": "Ford",
+      "gender": "F",
+      "dateOfBirth": "2007-01-20",
+      "contactable": "Y",
+      "capture": {
+        "urn": 333,
+        "createdDate": "2015-05-01T00:48:15Z",
+        "modifiedDate": "1996-06-23T00:48:15Z",
+        "lastUpdatedBy": "SOME_PERSON"
+      }
+    },
+    "addresses": [
+      {
+        "type": "HOME",
+        "contactable": "Y",
+        "lines": [
+          "30 Churchill Crescent"
+        ],
+        "townCity": "Stockport",
+        "county": "Cheshire",
+        "postcode": "SK5 6HZ",
+        "country": "GBR",
+        "capture": {
+          "urn": 333,
+          "createdDate": "2015-05-01T00:48:15Z",
+          "modifiedDate": "1996-06-23T00:48:15Z",
+          "lastUpdatedBy": "SOME_PERSON"
+        }
+      }
+    ],
+    "emails": [
+      {
+        "type": "PERSONAL",
+        "contactable": "Y",
+        "address": "hlittle0@clickbank.net",
+        "capture": {
+          "urn": 333,
+          "createdDate": "2015-05-01T00:48:15Z",
+          "modifiedDate": "1996-06-23T00:48:15Z",
+          "lastUpdatedBy": "SOME_PERSON"
+        }
+      }
+    ],
+    "phones": [
+      {
+        "type": "HOME",
+        "contactable": "Y",
+        "number": "235-(968)837-1009",
+        "capture": {
+          "urn": 333,
+          "createdDate": "2015-05-01T00:48:15Z",
+          "modifiedDate": "1996-06-23T00:48:15Z",
+          "lastUpdatedBy": "SOME_PERSON"
+        }
+      },
+      {
+        "type": "WORK",
+        "contactable": "N",
+        "number": "86-(289)664-5158",
+        "capture": {
+          "urn": 333,
+          "createdDate": "2015-05-01T00:48:15Z",
+          "modifiedDate": "1996-06-23T00:48:15Z",
+          "lastUpdatedBy": "SOME_PERSON"
+        }
+      },
+      {
+        "type": "MOBILE1",
+        "contactable": "Y",
+        "number": "86-(539)100-3079",
+        "capture": {
+          "urn": 333,
+          "createdDate": "2015-05-01T00:48:15Z",
+          "modifiedDate": "1996-06-23T00:48:15Z",
+          "lastUpdatedBy": "SOME_PERSON"
+        }
+      },
+      {
+        "type": "MOBILE2",
+        "contactable": "N",
+        "number": "55-(436)381-4883",
+        "capture": {
+          "urn": 333,
+          "createdDate": "2015-05-01T00:48:15Z",
+          "modifiedDate": "1996-06-23T00:48:15Z",
+          "lastUpdatedBy": "SOME_PERSON"
+        }
+      }
+    ],
+    "socials": [
+      {
+        "type": "Google",
+        "value": "google.ca",
+        "contactable": "Y",
+        "capture": {
+          "urn": 333,
+          "createdDate": "2015-05-01T00:48:15Z",
+          "modifiedDate": "1996-06-23T00:48:15Z",
+          "lastUpdatedBy": "SOME_PERSON"
+        }
+      },
+      {
+        "type": "Other",
+        "value": "sitemeter.com",
+        "contactable": "N",
+        "capture": {
+          "urn": 333,
+          "createdDate": "2015-05-01T00:48:15Z",
+          "modifiedDate": "1996-06-23T00:48:15Z",
+          "lastUpdatedBy": "SOME_PERSON"
+        }
+      }
+    ],
+    "additional": {
+      "PAFed": "N",
+      "customerType": "",
+      "inputDeliveryPointSuffix": "",
+      "deceasedInd": "",
+      "dateOfDeath": "",
+      "goneAwayInd": "",
+      "foreignAddressInd": "",
+      "mailPreferenceServiceInd": "",
+      "privilageCardNo": "",
+      "surpriseBookingInd": "",
+      "capture": {
+        "urn": 333,
+        "createdDate": "2015-05-01T00:48:15Z",
+        "modifiedDate": "1996-06-23T00:48:15Z",
+        "lastUpdatedBy": "SOME_PERSON"
+      }
+    }
+  }
+}

--- a/examples/update-enquiry-put.json
+++ b/examples/update-enquiry-put.json
@@ -1,0 +1,89 @@
+{
+  "urn": "ABCD",
+  "detail": {
+    "consultaitonRef": "ABCD",
+    "dealFields": {
+      "dealSequenceNumber": "1",
+      "dealStatusCode": "DSC",
+      "dealStatusCodeDescription": "DSCDesc",
+      "productTypeCode": "PTC",
+      "productTypeCodeDescription": "PTCDesc",
+      "productCode": "PC",
+      "productCodeDescription": "PCDesc",
+      "operatorCode": "OP",
+      "operatorCodeDescription": "OPDesc",
+      "brochureCode": "BC",
+      "brochureCodeDescription": "BCDesc",
+      "bookingReference": "5300/12345668",
+      "totalDueOnDeal": 25.36,
+      "amountDueDate": "22-FEB-16",
+      "numberOfAdults": 2,
+      "numberOfChildren": 1,
+      "numberOfInfants": 1,
+      "numberOfSeniorCitizens": 2,
+      "departureDate": "2016-10-26",
+      "totalCostNetOfDiscount": 3214.21,
+      "totalPaid": 325.01,
+      "lowDepositFlag": "Y",
+      "depositDueDate": "2016-09-26",
+      "depositAmount": 123.21,
+      "totalCostGross": 1354.21,
+      "dateDealConfirmed": "2016-05-26",
+      "dateDealCancelled": "2016-06-26",
+      "majorDestination": "LHR",
+      "staffEmployeeNumber": "nmb",
+      "transactionDate": "2016-04-26",
+      "abta": "L5876"
+    },
+    "travelLegs": [
+      {
+        "SequenceNumber": "13545",
+        "legType": "type",
+        "ISOCountryCodeArrival": "UA",
+        "ISOCountryCodeArrivalDescription": "UADesc",
+        "locationCodeArrival": "US",
+        "ISOCountryCodeDeparture": "US",
+        "ISOCountryCodeDepartureDescription": "USDesc",
+        "locationCodeDeparture": "locationCode",
+        "locationCodeDepartureDescription": "LCDesc",
+        "description": "resortDesc",
+        "cruiseShipName": "Queen Victoria",
+        "durationDays": 12,
+        "boardBasis": "AllInclusive",
+        "boardBasisDescription": "BSDesc",
+        "propertyCodeOrFlightNumber": "12OCD",
+        "propertyNameOrDestinationName": "13OCD",
+        "airlineName": "British Airwaivs",
+        "endDate": "2016-05-26",
+        "endTime": "12-28-32",
+        "startDate": "2016-05-26",
+        "startTime": "12-28-32"
+      }
+    ],
+    "costings": [
+      {
+        "costingSequenceNumber": "1354",
+        "costCode": "OC",
+        "quantityInvolved": 2,
+        "costUnitValue": 12.35,
+        "netCost": 10.32,
+        "description": "Operator cost"
+      }
+    ],
+    "manifestsCombined": [
+      {
+        "manifestSequenceNumber": "123564",
+        "leadPassengerFlag": "Y",
+        "passengerIncludeFlag": "Y",
+        "manifestType": "type",
+        "age": 25,
+        "passportTypeCode": "UK",
+        "title": "Mr",
+        "firstName": "Doe",
+        "surname": "Jhon",
+        "dateOfBirth": "1982-05-26"
+      }
+    ]
+  }
+}
+

--- a/tcocv.raml
+++ b/tcocv.raml
@@ -102,6 +102,14 @@ baseUri: http://server/api/{version}/tcocv
           404:
             description: The request was successful but no customer was found with that handover code
   /{customerID}:
+    put:
+      description: Updates a customer
+    body:
+      application/json:
+        example: !include examples/update-customer-put.json
+    responses:
+      200:
+        description: The customer was updated successfully
     get:
       description: Gets the specific customer information for this identifier
       responses:
@@ -324,31 +332,37 @@ baseUri: http://server/api/{version}/tcocv
                 example: !include examples/bookings.json
           404:
               description: The customer belonging to id provided could not be found   
-      /booking:      
-        /detail:
-          post:
-            description: Creates a booking, this will not interact with the summary block
+      post:
+        description: Creates a booking, this will not interact with the summary block
+        body:
+          application/json:
+            example: !include examples/create-booking.json
+        responses:
+          201:
+            description: The booking was created succesfully
+          400:
+            description: The request failed validation
+          403:
+            description: The access failed authentication
             body:
               application/json:
-                example: !include examples/create-booking.json
-            responses:
-              201:                
-                description: The booking was created succesfully                
-              400:
-                description: The request failed validation                 
-              403:
-                description: The access failed authentication
-                body:
-                  application/json:
-                    example: !include examples/security.json                                                  
-              404:
-                description: The customer belonging to id provided could not be found
-                body:
-                  application/json:
-                    example: !include examples/create-booking-not-found.json
-              409:
-                description: The bookingId already exists                
+                example: !include examples/security.json
+          404:
+            description: The customer belonging to id provided could not be found
+            body:
+              application/json:
+                example: !include examples/create-booking-not-found.json
+          409:
+            description: The bookingId already exists
       /{bookingID}:
+        put:
+          description: Updates a booking, this will not interact with the summary block
+        body:
+          application/json:
+            example: !include examples/update-booking-put.json
+        responses:
+          200:
+            description: The booking was updated successfully
         /detail:
           /dealFields:
             patch:
@@ -362,7 +376,7 @@ baseUri: http://server/api/{version}/tcocv
                   description: The access failed authentication
                   body:
                     application/json:
-                      example: !include examples/security.json 
+                      example: !include examples/security.json
                 404:
                   description: The booking ID or customer does not exist
                   body:
@@ -470,31 +484,37 @@ baseUri: http://server/api/{version}/tcocv
                   {}
           404:
               description: The customer belonging to ID provided could not be found   
-      /enquiry:      
-        /detail:
-          post:
-            description: Creates an enquiry, this will not interact with the summary block
+      post:
+        description: Creates an enquiry, this will not interact with the summary block
+        body:
+          application/json:
+            example: !include examples/create-enquiry.json
+        responses:
+          201:
+            description: The enquiry was created succesfully
+          400:
+            description: The request failed validation
+          403:
+            description: The access failed authentication
             body:
               application/json:
-                example: !include examples/create-enquiry.json
-            responses:
-              201:                
-                description: The enquiry was created succesfully                
-              400:
-                description: The request failed validation                 
-              403:
-                description: The access failed authentication
-                body:
-                  application/json:
-                    example: !include examples/security.json                                                  
-              404:
-                description: The customer belonging to ID provided could not be found
-                body:
-                  application/json:
-                    example: !include examples/create-enquiry-not-found.json
-              409:
-                description: The enquiryID already exists                
+                example: !include examples/security.json
+          404:
+            description: The customer belonging to ID provided could not be found
+            body:
+              application/json:
+                example: !include examples/create-enquiry-not-found.json
+          409:
+            description: The enquiryID already exists
       /{enquiryID}:
+        put:
+          description: Updates an enquiry, this will not interact with the summary block
+        body:
+          application/json:
+            example: !include examples/update-enquiry-put.json
+        responses:
+          200:
+            description: The enquiry was updated successfully
         /detail:
           /dealFields:
             patch:


### PR DESCRIPTION
Hello,

This is a proposal of improvement of the current API. The changes are in a draft stage just to show the concept.

What actually is proposed:
* Update customer, booking and enquiry by doing a PUT on `/customers/{customerId}`, `/bookings/{bookingId}` and `/enquiries/{enquiryId}` resources accordingly. Unlike in PATCH, the caller would send a full object which should replace the existing record
  * Useful if a caller doesn't know which exact fields need to be updated and only knows the full object state
  * Allows to update an enquiry or a booking with a single request, without doing separate update requests to subresources `dealFields`, `costings`, `travelLegs` and `manifestsCombined` 
* Create new bookings or enquiry by doing a POST on `/bookings` or `/enquiries` collections rather than on `/bookings/booking/detail` or `/enquiries/enquiry/detail`. This would be a more RESTful way, since we are posting a new record to a collection