### PR TITLE
Consolidated RAML examples to match responses from code

### DIFF
--- a/examples/costing-not-found.json
+++ b/examples/costing-not-found.json
@@ -1,8 +1,8 @@
 {
-	"errors": [
-		{
-			"code": 1012,
-			"condition": "Costings not found"
-		}
-	]
+    "errors": [
+        {
+            "code": 1012,
+            "condition": "Costings doesn't exist"
+        }
+    ]
 }

--- a/examples/create-booking-not-found.json
+++ b/examples/create-booking-not-found.json
@@ -2,11 +2,8 @@
     "errors": [
         {
             "code": 1009,
-            "location": "Create Booking",
-            "condition": "This can occur when Create Booking is requested for a customer id that does not match any customers",
-            "rationale": "Its possible for the customer id being passed in to be incorrect or corrupted. ",
-            "errorMessage": "The customer you are updating does not exist.  Please recheck the customer id you provided is correct.  The customer id you provided was <XXXX>",
-            "actionNeeded": "Please check that the customer id is correct to what was retrieved.  A ticket has been raised within GBG to confirm if this customer id exists."
+            "errorMessage": "The customer you are updating does not exist.  Please check the customer ID you provided is correct.  The customer ID you provided was 1234abcd.",
+            "location": "Create Booking"
         }
     ]
 }

--- a/examples/create-enquiry-not-found.json
+++ b/examples/create-enquiry-not-found.json
@@ -2,11 +2,8 @@
     "errors": [
         {
             "code": 1009,
-            "location": "Create Enquiry",
-            "condition": "This can occur when Create Enquiry is requested for a customer id that does not match any customers",
-            "rationale": "Its possible for the customer id being passed in to be incorrect or corrupted. ",
-            "errorMessage": "The customer you are updating does not exist.  Please recheck the customer id you provided is correct.  The customer id you provided was <XXXX>",
-            "actionNeeded": "Please check that the customer id is correct to what was retrieved.  A ticket has been raised within GBG to confirm if this customer id exists."
+            "errorMessage": "The customer you are updating does not exist.  Please check the customer ID you provided is correct.  The customer ID you provided was 1234abcd.",
+            "location": "Create Enquiry"
         }
     ]
 }

--- a/examples/customer.json
+++ b/examples/customer.json
@@ -21,73 +21,82 @@
         "lastUpdatedBy": "SOME_PERSON"
       }
     },
-    "addresses": [
-      {
-        "type": "HOME",
-        "contactable": "Y",
-        "lines": [
-          "12 KIRKVIEW CT",
-		  "BALLYMONEY",
-		  "BT53 6SB",
-		  "BALLYMONEY"
-        ],
-        "townCity": "BALLYMONEY",
-        "county": "CO ANTRIM",
-        "postcode": "BT53 6SB",
-        "country": "Northern Ireland",
-        "capture": {
-          "urn": 333,
-          "createdDate": "2015-05-01T00:48:15Z",
-          "modifiedDate": "1996-06-23T00:48:15Z",
-          "lastUpdatedBy": "SOME_PERSON"
-        },
-		"addressEnrichments":{
-		  "pafAddress":{
-			"matchScore":80,
-			"matchLevel":3,
-			"outputPostcodeLevel":5,
-			"buildingNo":"12",
-			"street":"KIRKVIEW COURT",
-			"town":"BALLYMONEY",
-			"county":"CO ANTRIM",
-			"postcode":"BT536SB",
-			"udprn":"03642388"
-		  },
-		  "cleansedAddress":{
-			"addressID":"9f1563e285de6454eb442fc947fc9586",
-			"lines":[
-			  "12 KIRKVIEW CT",
-			  "BALLYMONEY",
-			  "BT53 6SB",
-			  ""
-			],
-			"postcode":"BT536SB",
-			"country":"N IRELAND",
-			"geokey":{
-			  "place":{
-				"countryCode":"ENGLAND",
-				"townCodeKey":"00087",
-				"localityCodeKey":"00000",
-				"postcodeKey":"0603936"
-			  },
-			  "location":{
-				"streetCodeKey":"K62100",
-				"streetType":"CT",
-				"maxNo":"30303132",
-				"minNo":"30303132",
-				"otherKey":"30303132",
-				"streetName":"KIRKVIEW"
-			  }
-			},
-			"capture":{
-			  "urn":333,
-			  "createdDate":"01/01/2015",
-			  "modifiedDate":"01/01/2015"
-			}
-		  }
-		}
+    "addresses":    [
+            {
+         "type": "HOME",
+         "contactable": "Y",
+         "inputAddress":          {
+            "lines":             [
+               "1 SYMPSON RD",
+               "",
+               "TADLEY",
+               "RG26 3UU",
+               "TADLEY"
+            ],
+            "postcode": "RG26 3UU",
+            "country": "ENGLAND"
+         },
+         "cleansedAddress":          {
+            "lines":             [
+               "1 SYMPSON RD",
+               "TADLEY",
+               "RG26 3UU",
+               ""
+            ],
+            "postcode": "RG263UU",
+            "country": "ENGLAND"
+         },
+         "pafAddress":          {
+            "buildingNo": "1",
+            "street": "SYMPSON ROAD",
+            "town": "TADLEY",
+            "county": "HANTS",
+            "postcode": "RG263UU"
+         },
+         "capture":          {
+            "urn": "222",
+            "createdDate": "01/01/2015",
+            "modifiedDate": "01/01/2015"
+         }
+      },
+            {
+         "type": "WORK",
+         "contactable": "Y",
+         "inputAddress":          {
+            "lines":             [
+               "1 SYMPSON RD",
+               "",
+               "TADLEY",
+               "RG26 3UU",
+               "TADLEY"
+            ],
+            "postcode": "RG26 3UU",
+            "country": "ENGLAND"
+         },
+         "cleansedAddress":          {
+            "lines":             [
+               "1 SYMPSON RD",
+               "TADLEY",
+               "RG26 3UU",
+               ""
+            ],
+            "postcode": "RG263UU",
+            "country": "ENGLAND"
+         },
+         "pafAddress":          {
+            "buildingNo": "1",
+            "street": "SYMPSON ROAD",
+            "town": "TADLEY",
+            "county": "HANTS",
+            "postcode": "RG263UU"
+         },
+         "capture":          {
+            "urn": "222",
+            "createdDate": "01/01/2015",
+            "modifiedDate": "01/01/2015"
+         }
       }
-    ],
+   ],
     "emails": [
       {
         "type": "PERSONAL",

--- a/examples/manifest-not-found.json
+++ b/examples/manifest-not-found.json
@@ -1,8 +1,8 @@
 {
-	"errors": [
-		{
-			"code": 1011,
-			"condition": "Manifest not found"
-		}
-	]
+    "errors": [
+        {
+            "code": 1013,
+            "condition": "Manifest doesn't exist"
+        }
+    ]
 }

--- a/examples/search.json
+++ b/examples/search.json
@@ -1,4 +1,4 @@
-
+[
   {
     "customer": {
       "identity": {

--- a/tcocv.raml
+++ b/tcocv.raml
@@ -56,7 +56,6 @@ baseUri: http://server/api/{version}/tcocv
         description: The request failed validation.  The exact errors are captured in the JSON response
         body:
           application/json:
-            example: !include examples/create-invalid.json
       403:
         description: The access failed authentication
         body:
@@ -164,7 +163,6 @@ baseUri: http://server/api/{version}/tcocv
             description: The request was successful
             body:
               application/json:
-                example: !include examples/stats.json
           204:
             description: The request was succesful but no customer was found with that ID. An empty element is returned
             body:
@@ -204,7 +202,6 @@ baseUri: http://server/api/{version}/tcocv
             description: The request was successful
             body:
               application/json:
-                example: !include examples/communications.json
           204:
             description: The request was succesful but no customer was found with that ID.  An empty element is returned
             body:
@@ -224,7 +221,6 @@ baseUri: http://server/api/{version}/tcocv
             description: The request was successful and preferences have been found
             body:
               application/json:
-                example: !include examples/preferences.json
           204:
             description: The request was succesful but no preferences were found.  An empty element is returned
             body:
@@ -307,7 +303,6 @@ baseUri: http://server/api/{version}/tcocv
             description: The request was successful
             body:
               application/json:
-                example: !include examples/marketing-options.json
           204:
             description: The request was succesful but no customer was found with that ID. An empty element is returned
             body:


### PR DESCRIPTION
Updated Address block in customer.json to match what is returned from code - removed "AddressEnrichments" section
Removed reference to example files in RAML for functionality that has not been implemented yet as these may not be accurate
Updated error codes/responses to match what is returned from the code